### PR TITLE
task #9: catalogo de estados de mexico

### DIFF
--- a/src/etl/catalog/__init__.py
+++ b/src/etl/catalog/__init__.py
@@ -1,0 +1,1 @@
+"""Submódulo de catálogos útiles."""

--- a/src/etl/catalog/catalog.py
+++ b/src/etl/catalog/catalog.py
@@ -1,0 +1,44 @@
+"""Catalogos para peticiones de la API de INEGI."""
+
+from enum import IntEnum
+
+
+class StatesCodes(IntEnum):
+    """Códigos de estados de México."""
+    MX = 0  # Todo el país
+    AGUASCALIENTES = 1
+    BAJA_CALIFORNIA = 2
+    BAJA_CALIFORNIA_SUR = 3
+    CAMPECHE = 4
+    CHIAPAS = 5
+    CHIHUAHUA = 6
+    CDMX = 7
+    COAHUILA = 8
+    COLIMA = 9
+    DURANGO = 10
+    GUANAJUATO = 11
+    GUERRERO = 12
+    HIDALGO = 13
+    JALISCO = 14
+    MICHOACAN = 15
+    MORELOS = 16
+    MEXICO = 17
+    NAYARIT = 18
+    NUEVO_LEON = 19
+    OAXACA = 20
+    PUEBLA = 21
+    QUERETARO = 22
+    QUINTANA_ROO = 23
+    SAN_LUIS_POTOSI = 24
+    SINALOA = 25
+    SONORA = 26
+    TABASCO = 27
+    TAMAULIPAS = 28
+    TLAXCALA = 29
+    VERACRUZ = 30
+    YUCATAN = 31
+    ZACATECAS = 32
+
+if __name__ == "__main__":
+    from pprint import pprint
+    pprint(StatesCodes.__members__)

--- a/test/catalog_test.py
+++ b/test/catalog_test.py
@@ -1,0 +1,21 @@
+"""Tests de submódulo de catálogos."""
+
+import pytest
+
+from etl.catalog.catalog import StatesCodes
+
+NUM_STATES = 33  # Uno mas por el asignado al país completo
+VALID_STATES = ["AGUASCALIENTES", "BAJA_CALIFORNIA", "CAMPECHE", "YUCATAN"]
+
+
+class TestStateCode:
+    """Test catálogo de códigos de estados mexicanos."""
+
+    def test_valid_number_of_states(self) -> None:
+        """Revisa que el número de estados en el Enum sea igual al esperado."""
+        assert len(StatesCodes) == NUM_STATES
+
+    @pytest.mark.parametrize("state", VALID_STATES)
+    def test_expected_members(self, state: str) -> None:
+        """Revisa que contenga todos los estados esperados el catálogo."""
+        assert state in StatesCodes._member_names_


### PR DESCRIPTION
## Summary
Añade un catálogo de estados de México asociado a un valor numérico de la manera que lo maneja INEGI.

## Changes
List the key changes in this PR:
- [x] Enum para representar estados de México y asociarlos a un número.

## Checklist
- [x] I have tested my changes locally
- [x] I added/updated documentation if needed
- [x] I added/updated tests
- [x] CI pipeline is passing

## Related Issues
Closes #9
